### PR TITLE
Removed networkName in create network

### DIFF
--- a/include/Tanja84dk/api.h
+++ b/include/Tanja84dk/api.h
@@ -150,7 +150,7 @@ namespace Tanja84dk::DockerLib::API
       return "/networks/" + networkName;
     }
 
-    std::string create(const std::string &networkName)
+    std::string create()
     {
       return "/networks/create";
     }


### PR DESCRIPTION
Removed the networkName in the function for returning the API path for creating a network.

The reason is that when ever you create a network then the network name goes into the body of the request and not in the path